### PR TITLE
Add support for custom path of the client secret file

### DIFF
--- a/ezGmail.go
+++ b/ezGmail.go
@@ -122,7 +122,7 @@ func (gs *GmailService) InitSrv(credentialFilePath string) {
 	// Connect and create gmail.Service object
         ctx := context.Background()
 
-        b, err := ioutil.ReadFile("client_secret.json")
+        b, err := ioutil.ReadFile(credentialFilePath)
         if err != nil {
                 log.Fatalf("Unable to read client secret file: %v", err)
         }

--- a/ezGmail.go
+++ b/ezGmail.go
@@ -118,29 +118,33 @@ type GmailService struct {
 /*
 	credentialFilePath is the loaction of 'credential-json' file
  */
-func (gs *GmailService) InitSrv(credentialFilePath string) {
+func (gs *GmailService) InitSrvWithCrentialAt(credentialFilePath string) {
 	// Connect and create gmail.Service object
-        ctx := context.Background()
+	ctx := context.Background()
 
-        b, err := ioutil.ReadFile(credentialFilePath)
-        if err != nil {
-                log.Fatalf("Unable to read client secret file: %v", err)
-        }
+	b, err := ioutil.ReadFile(credentialFilePath)
+	if err != nil {
+		log.Fatalf("Unable to read client secret file at %s : %v", credentialFilePath,err)
+	}
 
-        config, err := google.ConfigFromJSON(b, gmail.GmailReadonlyScope)
-        if err != nil {
-                log.Fatalf("Unable to parse client secret file to config: %v", err)
-        }
-        client := getClient(ctx, config)
+	config, err := google.ConfigFromJSON(b, gmail.GmailReadonlyScope)
+	if err != nil {
+		log.Fatalf("Unable to parse client secret file to config: %v", err)
+	}
+	client := getClient(ctx, config)
 
-        gs.srv, err = gmail.New(client)
-        if err != nil {
-                log.Fatalf("Unable to retrieve gmail Client %v", err)
-        }
+	gs.srv, err = gmail.New(client)
+	if err != nil {
+		log.Fatalf("Unable to retrieve gmail Client %v", err)
+	}
 
 	// Assign Defaults
 	gs.iMaxResults = 50
 	gs.sUser       = "me"
+}
+
+func (gs *GmailService) InitSrv() {
+	gs.InitSrvWithCrentialAt("client_secret.json")
 }
 
 func (gs *GmailService) MaxResults	(maxres         int64 ) *GmailService	{ gs.iMaxResults	= maxres    ; return gs }

--- a/ezGmail.go
+++ b/ezGmail.go
@@ -115,7 +115,10 @@ type GmailService struct {
 	sHasAttachment   bool
 }
 
-func (gs *GmailService) InitSrv() {
+/*
+	credentialFilePath is the loaction of 'credential-json' file
+ */
+func (gs *GmailService) InitSrv(credentialFilePath string) {
 	// Connect and create gmail.Service object
         ctx := context.Background()
 


### PR DESCRIPTION
Its very inconvenient for a user of this library when he/she is forced to place client secret file in the same directory and with a name dictated by this library.

I loved this simple library except it should have provided me an ability to pass the above mentioned filePath.

This PR intends to solve the above pain-point.

Changes:

- InitSrvWithCredentialAt to accept a string argument which is the location of the client secret file